### PR TITLE
Add an optional timeout parameter to inotify_wait

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -14,7 +14,7 @@ update_port () {
 while true; do
   if [ -f $PORT_FORWARDED ]; then
     update_port
-    inotifywait -mq -e close_write $PORT_FORWARDED | while read change; do
+    inotifywait -mq -t ${PORT_UPDATE_TIMEOUT:-0} -e close_write $PORT_FORWARDED | while read change; do
       update_port
     done
   else


### PR DESCRIPTION
Optionally timeout inotify_wait to update qbittorrent's listening port on a periodic basis. The default value (if the environment variable is not set) is to have no timeout, so there is no change in functionality if the parameter is unset.

This helps with situations where, for example, qbittorrent has restarted and is using its default listening port, but gluetun has not updated its forwarded port, leaving qbittorrent unaware of the forwarded port.