### PR TITLE
Add validation for current qbittorrent listen_port value.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,13 +2,34 @@
 
 COOKIES="/tmp/cookies.txt"
 
+check_qbt_port () {
+  RESPONSE_PORT=$(curl -s -b $COOKIES ${HTTP_S}://${QBITTORRENT_SERVER}:${QBITTORRENT_PORT}/api/v2/app/preferences | sed -n 's/.*"listen_port":\([0-9]*\).*/\1/p')
+}
+
 update_port () {
   PORT=$(cat $PORT_FORWARDED)
+  TIMESTAMP=`date "+%Y-%m-%d %H:%M:%S"`
   rm -f $COOKIES
   curl -s -c $COOKIES --data "username=$QBITTORRENT_USER&password=$QBITTORRENT_PASS" ${HTTP_S}://${QBITTORRENT_SERVER}:${QBITTORRENT_PORT}/api/v2/auth/login > /dev/null
-  curl -s -b $COOKIES --data 'json={"listen_port": "'"$PORT"'"}' ${HTTP_S}://${QBITTORRENT_SERVER}:${QBITTORRENT_PORT}/api/v2/app/setPreferences > /dev/null
+  check_qbt_port
+
+  if [[ "$RESPONSE_PORT" == "$PORT" ]]
+  then
+   echo "$TIMESTAMP qbitorrent port is up to date. gluetun: $PORT, qbittorrent: $RESPONSE_PORT"
+  else
+   echo "$TIMESTAMP Current qbittorrent port is $RESPONSE_PORT. Updating qbittorrent to port $PORT"
+   curl -s -b $COOKIES --data 'json={"listen_port": "'"$PORT"'"}' ${HTTP_S}://${QBITTORRENT_SERVER}:${QBITTORRENT_PORT}/api/v2/app/setPreferences > /dev/null
+   check_qbt_port
+   if [[ "$RESPONSE_PORT" == "$PORT" ]]
+   then
+    echo "$TIMESTAMP Updated qbittorrent to port $PORT. Current qbittorrent port is $RESPONSE_PORT"
+   else
+    echo "$TIMESTAMP Failed to update qbittorrent to port $PORT. Current qbittorrent port is $RESPONSE_PORT"
+   fi
+  fi
+
   rm -f $COOKIES
-  echo "Successfully updated qbittorrent to port $PORT"
+
 }
 
 while true; do


### PR DESCRIPTION
Added validation for current qbittorrent listen_port value (got that from curl response).
Added clear logging with simple timestamp.

Sample logs when port in qbittorrent is different than that in reponse from gluetun:
```
2024-10-01 19:29:34 Current qbittorrent port is 6881. Updating qbittorrent to port 39648
2024-10-01 19:29:34 Updated qbittorrent to port 39648. Current qbittorrent port is 39648
```

and when port is set correctly:
```
2024-10-01 19:35:54 qbitorrent port is up to date. gluetun: 39648, qbittorrent: 39648
```